### PR TITLE
Adding multi-arch to jvm based profiling

### DIFF
--- a/.github/workflows/do-release.yml
+++ b/.github/workflows/do-release.yml
@@ -42,6 +42,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:
@@ -49,9 +55,10 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PASSWORD }}
 
       - name: Build and Push JVM Agent Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: 'docker/jvm/Dockerfile'
           push: true
           tags: |
@@ -59,9 +66,10 @@ jobs:
             ghcr.io/josepdcs/kubectl-prof:${{ env.tag }}-jvm
 
       - name: Build and Push JVM Alpine Agent Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: 'docker/jvm/alpine/Dockerfile'
           push: true
           tags: |
@@ -69,9 +77,10 @@ jobs:
             ghcr.io/josepdcs/kubectl-prof:${{ env.tag }}-jvm-alpine
 
       - name: Build and Push BPF Agent Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: 'docker/bpf/Dockerfile'
           push: true
           tags: |
@@ -79,9 +88,10 @@ jobs:
             ghcr.io/josepdcs/kubectl-prof:${{ env.tag }}-bpf
 
       - name: Build and Push Python Agent Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: 'docker/python/Dockerfile'
           push: true
           tags: |
@@ -89,9 +99,10 @@ jobs:
             ghcr.io/josepdcs/kubectl-prof:${{ env.tag }}-python
 
       - name: Build and Push Ruby Agent Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: 'docker/ruby/Dockerfile'
           push: true
           tags: |
@@ -99,9 +110,10 @@ jobs:
             ghcr.io/josepdcs/kubectl-prof:${{ env.tag }}-ruby
 
       - name: Build and Push Perf Agent Image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           file: 'docker/perf/Dockerfile'
           push: true
           tags: |

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ DOCKERFILE_PYTHON ?= ./docker/python/Dockerfile
 DOCKER_RUBY_IMAGE ?= $(DOCKER_BASE_IMAGE):$(VERSION)-ruby
 DOCKERFILE_RUBY ?= ./docker/ruby/Dockerfile
 DOCKER_TARGET_PLATFORM ?= linux/amd64,linux/arm64
+DOCKER_BUILD_ADDITIONAL_ARGS ?= 
 
 M = $(shell printf "\033[34;1m▶\033[0m")
 
@@ -56,7 +57,7 @@ build-agent: install-deps ## Build the binary file
 .PHONY: build-docker-jvm
 build-docker-jvm:
 	$(info $(M) building JVM docker image...)
-	@docker buildx build --progress plain --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_JVM_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_JVM) .
+	@docker buildx build ${DOCKER_BUILD_ADDITIONAL_ARGS} --progress plain --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_JVM_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_JVM) .
 
 ## push-docker-jvm: Build and push the JVM docker image
 .PHONY: push-docker-jvm
@@ -68,7 +69,7 @@ push-docker-jvm: build-docker-jvm
 .PHONY: build-docker-jvm-alpine
 build-docker-jvm-alpine:
 	$(info $(M) building JVM Alpine docker image...)
-	@docker buildx build --progress plain --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_JVM_ALPINE_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_JVM_ALPINE) .
+	@docker buildx build ${DOCKER_BUILD_ADDITIONAL_ARGS} --progress plain --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_JVM_ALPINE_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_JVM_ALPINE) .
 
 ## push-docker-jvm-alpine: Build and push the JVM docker image for Alpine
 .PHONY: push-docker-jvm-alpine
@@ -80,7 +81,7 @@ push-docker-jvm-alpine: build-docker-jvm-alpine
 .PHONY: build-docker-bpf
 build-docker-bpf:
 	$(info $(M) building BPF docker image...)
-	docker buildx build --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_BPF_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_BPF) .
+	docker buildx build ${DOCKER_BUILD_ADDITIONAL_ARGS} --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_BPF_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_BPF) .
 
 ## push-docker-bpf: Build and push the BPF docker image
 .PHONY: push-docker-bpf
@@ -92,7 +93,7 @@ push-docker-bpf: build-docker-bpf
 .PHONY: build-docker-perf
 build-docker-perf:
 	$(info $(M) building PERF docker image...)
-	docker buildx build --platform=${DOCKER_TARGET_PLATFORM} --no-cache -t ${DOCKER_PERF_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_PERF) .
+	docker buildx build ${DOCKER_BUILD_ADDITIONAL_ARGS} --platform=${DOCKER_TARGET_PLATFORM} --no-cache -t ${DOCKER_PERF_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_PERF) .
 
 ## push-docker-perf: Build and push the PERF docker image
 .PHONY: push-docker-perf
@@ -104,7 +105,7 @@ push-docker-perf: build-docker-perf
 .PHONY: build-docker-python
 build-docker-python:
 	$(info $(M) building PYTHON docker image...)
-	docker buildx build --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_PYTHON_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_PYTHON) .
+	docker buildx build ${DOCKER_BUILD_ADDITIONAL_ARGS} --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_PYTHON_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_PYTHON) .
 
 ## push-docker-python: Build and push the PYTHON docker image
 .PHONY: push-docker-python
@@ -116,7 +117,7 @@ push-docker-python: build-docker-python
 .PHONY: build-docker-ruby
 build-docker-ruby:
 	$(info $(M) building RUBY docker image...)
-	docker buildx build --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_RUBY_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_RUBY) .
+	docker buildx build ${DOCKER_BUILD_ADDITIONAL_ARGS} --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_RUBY_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_RUBY) .
 
 ## push-docker-ruby: Build and push the RUBY docker image
 .PHONY: push-docker-ruby

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ DOCKER_PYTHON_IMAGE ?= $(DOCKER_BASE_IMAGE):$(VERSION)-python
 DOCKERFILE_PYTHON ?= ./docker/python/Dockerfile
 DOCKER_RUBY_IMAGE ?= $(DOCKER_BASE_IMAGE):$(VERSION)-ruby
 DOCKERFILE_RUBY ?= ./docker/ruby/Dockerfile
+DOCKER_TARGET_PLATFORM ?= linux/amd64,linux/arm64
 
 M = $(shell printf "\033[34;1m▶\033[0m")
 
@@ -55,7 +56,7 @@ build-agent: install-deps ## Build the binary file
 .PHONY: build-docker-jvm
 build-docker-jvm:
 	$(info $(M) building JVM docker image...)
-	@docker build -t ${DOCKER_JVM_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_JVM) .
+	@docker buildx build --progress plain --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_JVM_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_JVM) .
 
 ## push-docker-jvm: Build and push the JVM docker image
 .PHONY: push-docker-jvm
@@ -67,7 +68,7 @@ push-docker-jvm: build-docker-jvm
 .PHONY: build-docker-jvm-alpine
 build-docker-jvm-alpine:
 	$(info $(M) building JVM Alpine docker image...)
-	@docker build -t ${DOCKER_JVM_ALPINE_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_JVM_ALPINE) .
+	@docker buildx build --progress plain --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_JVM_ALPINE_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_JVM_ALPINE) .
 
 ## push-docker-jvm-alpine: Build and push the JVM docker image for Alpine
 .PHONY: push-docker-jvm-alpine
@@ -79,7 +80,7 @@ push-docker-jvm-alpine: build-docker-jvm-alpine
 .PHONY: build-docker-bpf
 build-docker-bpf:
 	$(info $(M) building BPF docker image...)
-	docker build -t ${DOCKER_BPF_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_BPF) .
+	docker buildx build --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_BPF_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_BPF) .
 
 ## push-docker-bpf: Build and push the BPF docker image
 .PHONY: push-docker-bpf
@@ -91,7 +92,7 @@ push-docker-bpf: build-docker-bpf
 .PHONY: build-docker-perf
 build-docker-perf:
 	$(info $(M) building PERF docker image...)
-	docker build --no-cache -t ${DOCKER_PERF_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_PERF) .
+	docker buildx build --platform=${DOCKER_TARGET_PLATFORM} --no-cache -t ${DOCKER_PERF_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_PERF) .
 
 ## push-docker-perf: Build and push the PERF docker image
 .PHONY: push-docker-perf
@@ -103,7 +104,7 @@ push-docker-perf: build-docker-perf
 .PHONY: build-docker-python
 build-docker-python:
 	$(info $(M) building PYTHON docker image...)
-	docker build -t ${DOCKER_PYTHON_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_PYTHON) .
+	docker buildx build --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_PYTHON_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_PYTHON) .
 
 ## push-docker-python: Build and push the PYTHON docker image
 .PHONY: push-docker-python
@@ -115,7 +116,7 @@ push-docker-python: build-docker-python
 .PHONY: build-docker-ruby
 build-docker-ruby:
 	$(info $(M) building RUBY docker image...)
-	docker build -t ${DOCKER_RUBY_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_RUBY) .
+	docker buildx build --platform=${DOCKER_TARGET_PLATFORM} -t ${DOCKER_RUBY_IMAGE} --label git-commit=$(shell git rev-parse HEAD) -f $(DOCKERFILE_RUBY) .
 
 ## push-docker-ruby: Build and push the RUBY docker image
 .PHONY: push-docker-ruby

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -7,10 +7,10 @@ WORKDIR /go/src/github.com/josepdcs/kubectl-prof/cmd/agent
 RUN go build -o /go/bin/agent
 
 
-FROM --platform=$BUILDPLATFORM eclipse-temurin:$JAVA_VERSION_TAG-alpine AS tools
+FROM --platform=$BUILDPLATFORM eclipse-temurin:$JAVA_VERSION_TAG AS tools
 ARG TARGETPLATFORM
 ARG ASYNCP_VERSION=2.9
-RUN apk add --no-cache curl tar wget
+RUN apt-get update && apt-get install -y curl tar wget
 # Echo variables to debug and ensure they hold the expected values
 RUN echo "ASYNCP_VERSION=${ASYNCP_VERSION}, TARGETPLATFORM=${TARGETPLATFORM}"
 
@@ -34,11 +34,10 @@ RUN mkdir -p /app/async-profiler/build
 COPY --from=agentbuild /go/bin/agent /app
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/jvm/profiler.sh /app/async-profiler
 COPY --from=tools /async-profiler/build /app/async-profiler/build
-COPY --from=tools /jcmd /opt/jdk/bin/jcmd
+COPY --from=tools /jcmd /opt/jdk
 RUN chmod +x /app/async-profiler/profiler.sh
 RUN mkdir -p /app/jfr/settings
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/jvm/jfr-profile.jfc /app/jfr/settings
-# COPY --from=tools /jdk /opt/jdk
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/get-ps-command.sh /app/get-ps-command.sh
 RUN chmod +x /app/get-ps-command.sh
 

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -6,24 +6,35 @@ RUN go get -d -v ./...
 WORKDIR /go/src/github.com/josepdcs/kubectl-prof/cmd/agent
 RUN go build -o /go/bin/agent
 
-FROM --platform=$BUILDPLATFORM alpine:3.18.4 AS tools
+
+FROM --platform=$BUILDPLATFORM eclipse-temurin:$JAVA_VERSION_TAG-alpine AS tools
 ARG TARGETPLATFORM
 ARG ASYNCP_VERSION=2.9
 RUN apk add --no-cache curl tar wget
 # Echo variables to debug and ensure they hold the expected values
 RUN echo "ASYNCP_VERSION=${ASYNCP_VERSION}, TARGETPLATFORM=${TARGETPLATFORM}"
 
+RUN $JAVA_HOME/bin/jlink \
+         --module-path jmods \
+         --add-modules jdk.jcmd \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /jcmd
+
 # Determine the architecture based on the platform
 RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=x64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=x64; fi \
 && wget -O async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz https://github.com/jvm-profiling-tools/async-profiler/releases/download/v${ASYNCP_VERSION}/async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz \
 && tar -xf async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz && mv async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE} async-profiler
 
-FROM --platform=$TARGETPLATFORM bitnami/java:$JAVA_VERSION_TAG
+FROM --platform=$TARGETPLATFORM bitnami/minideb:bullseye
 RUN apt-get update && apt-get install -y procps strace sudo gzip
 RUN mkdir -p /app/async-profiler/build
 COPY --from=agentbuild /go/bin/agent /app
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/jvm/profiler.sh /app/async-profiler
 COPY --from=tools /async-profiler/build /app/async-profiler/build
+COPY --from=tools /jcmd /opt/jdk/bin/jcmd
 RUN chmod +x /app/async-profiler/profiler.sh
 RUN mkdir -p /app/jfr/settings
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/jvm/jfr-profile.jfc /app/jfr/settings

--- a/docker/jvm/Dockerfile
+++ b/docker/jvm/Dockerfile
@@ -1,22 +1,24 @@
-FROM golang:1.21.6-bullseye AS agentbuild
+ARG JAVA_VERSION_TAG=21
+FROM --platform=$BUILDPLATFORM golang:1.21.6-bullseye AS agentbuild
 WORKDIR /go/src/github.com/josepdcs/kubectl-prof
 ADD . /go/src/github.com/josepdcs/kubectl-prof
 RUN go get -d -v ./...
 WORKDIR /go/src/github.com/josepdcs/kubectl-prof/cmd/agent
 RUN go build -o /go/bin/agent
 
-FROM alpine:3.18.4 AS tools
-RUN apk add --no-cache curl
-# Download async-profiler
-RUN curl -o async-profiler-2.9-linux-x64.tar.gz -L \
-    https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-x64.tar.gz
-RUN tar -xf async-profiler-2.9-linux-x64.tar.gz && mv async-profiler-2.9-linux-x64 async-profiler
-# Download jdk-21
-RUN curl -o jdk-21.0.1+12.tar.gz -L \
-    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1+12/OpenJDK21U-jdk_x64_linux_hotspot_21.0.1_12.tar.gz
-RUN tar -xf jdk-21.0.1+12.tar.gz && mv jdk-21.0.1+12 jdk
+FROM --platform=$BUILDPLATFORM alpine:3.18.4 AS tools
+ARG TARGETPLATFORM
+ARG ASYNCP_VERSION=2.9
+RUN apk add --no-cache curl tar wget
+# Echo variables to debug and ensure they hold the expected values
+RUN echo "ASYNCP_VERSION=${ASYNCP_VERSION}, TARGETPLATFORM=${TARGETPLATFORM}"
 
-FROM bitnami/minideb:bullseye
+# Determine the architecture based on the platform
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=x64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=x64; fi \
+&& wget -O async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz https://github.com/jvm-profiling-tools/async-profiler/releases/download/v${ASYNCP_VERSION}/async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz \
+&& tar -xf async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz && mv async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE} async-profiler
+
+FROM --platform=$TARGETPLATFORM bitnami/java:$JAVA_VERSION_TAG
 RUN apt-get update && apt-get install -y procps strace sudo gzip
 RUN mkdir -p /app/async-profiler/build
 COPY --from=agentbuild /go/bin/agent /app
@@ -25,7 +27,7 @@ COPY --from=tools /async-profiler/build /app/async-profiler/build
 RUN chmod +x /app/async-profiler/profiler.sh
 RUN mkdir -p /app/jfr/settings
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/jvm/jfr-profile.jfc /app/jfr/settings
-COPY --from=tools /jdk /opt/jdk
+# COPY --from=tools /jdk /opt/jdk
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/get-ps-command.sh /app/get-ps-command.sh
 RUN chmod +x /app/get-ps-command.sh
 

--- a/docker/jvm/alpine/Dockerfile
+++ b/docker/jvm/alpine/Dockerfile
@@ -1,22 +1,21 @@
-FROM golang:1.21.6-alpine AS agentbuild
+ARG JAVA_VERSION_TAG=21
+ARG ASYNCP_VERSION=2.9
+FROM --platform=$BUILDPLATFORM golang:1.21.6-alpine AS agentbuild
 WORKDIR /go/src/github.com/josepdcs/kubectl-prof
 ADD . /go/src/github.com/josepdcs/kubectl-prof
 RUN go get -d -v ./...
 WORKDIR /go/src/github.com/josepdcs/kubectl-prof/cmd/agent
 RUN go build -o /go/bin/agent
 
-FROM alpine:3.18.4 AS tools
-RUN apk add --no-cache curl
+FROM --platform=$BUILDPLATFORM alpine:3.18.4 AS tools
+ARG TARGETPLATFORM
+RUN apk add --no-cache curl wget
 # Download async-profiler
-RUN curl -o async-profiler-2.8-linux-musl-x64.tar.gz -L \
-    https://github.com/async-profiler/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-musl-x64.tar.gz
-RUN tar -xvf async-profiler-2.8-linux-musl-x64.tar.gz && mv async-profiler-2.9-linux-musl-x64 async-profiler
-# Download jdk
-RUN curl -o jdk-21.0.1+12.tar.gz -L \
-    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1+12/OpenJDK21U-jdk_x64_alpine-linux_hotspot_21.0.1_12.tar.gz
-RUN tar -xf jdk-21.0.1+12.tar.gz && mv jdk-21.0.1+12 jdk
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=x64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=x64; fi \
+&& wget -O async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz https://github.com/jvm-profiling-tools/async-profiler/releases/download/v${ASYNCP_VERSION}/async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz \
+&& tar -xf async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz && mv async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE} async-profiler
 
-FROM alpine:3.18.4
+FROM --platform=$TARGETPLATFORM amazoncorretto:$JAVA_VERSION_TAG-alpine
 RUN mkdir -p /app/async-profiler/build
 RUN apk add --no-cache procps
 COPY --from=agentbuild /go/bin/agent /app
@@ -25,7 +24,6 @@ COPY --from=tools /async-profiler/build /app/async-profiler/build
 RUN chmod +x /app/async-profiler/profiler.sh
 RUN mkdir -p /app/jfr/settings
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/jvm/jfr-profile.jfc /app/jfr/settings
-COPY --from=tools /jdk /opt/jdk
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/get-ps-command.sh /app/get-ps-command.sh
 RUN chmod +x /app/get-ps-command.sh
 

--- a/docker/jvm/alpine/Dockerfile
+++ b/docker/jvm/alpine/Dockerfile
@@ -7,20 +7,39 @@ RUN go get -d -v ./...
 WORKDIR /go/src/github.com/josepdcs/kubectl-prof/cmd/agent
 RUN go build -o /go/bin/agent
 
-FROM --platform=$BUILDPLATFORM alpine:3.18.4 AS tools
+FROM --platform=$BUILDPLATFORM amazoncorretto:11-alpine-jdk AS async-profiler-builder
 ARG TARGETPLATFORM
-RUN apk add --no-cache curl wget
-# Download async-profiler
-RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then ARCHITECTURE=x64; elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then ARCHITECTURE=arm64; else ARCHITECTURE=x64; fi \
-&& wget -O async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz https://github.com/jvm-profiling-tools/async-profiler/releases/download/v${ASYNCP_VERSION}/async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz \
-&& tar -xf async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE}.tar.gz && mv async-profiler-${ASYNCP_VERSION}-linux-${ARCHITECTURE} async-profiler
+ARG ASYNCP_VERSION=2.9
+RUN apk add --no-cache curl tar wget g++ linux-headers musl-dev git make
+WORKDIR /src
+RUN git clone --branch v${ASYNCP_VERSION} --depth 1 https://github.com/async-profiler/async-profiler
+WORKDIR /src/async-profiler
+RUN make CXXFLAGS='-O3 -fno-omit-frame-pointer -fvisibility=hidden -D_LARGEFILE64_SOURCE' all native; \
+    tree -d /src;
 
-FROM --platform=$TARGETPLATFORM amazoncorretto:$JAVA_VERSION_TAG-alpine
+FROM --platform=$BUILDPLATFORM eclipse-temurin:$JAVA_VERSION_TAG-alpine AS tools
+ARG TARGETPLATFORM
+ARG ASYNCP_VERSION=2.9
+RUN apk add --no-cache curl tar wget g++ linux-headers git make
+# Echo variables to debug and ensure they hold the expected values
+RUN echo "ASYNCP_VERSION=${ASYNCP_VERSION}, TARGETPLATFORM=${TARGETPLATFORM}"
+
+RUN $JAVA_HOME/bin/jlink \
+         --module-path jmods \
+         --add-modules jdk.jcmd \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /jcmd
+
+FROM --platform=$TARGETPLATFORM alpine:3.18.4
 RUN mkdir -p /app/async-profiler/build
 RUN apk add --no-cache procps
 COPY --from=agentbuild /go/bin/agent /app
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/jvm/profiler.sh /app/async-profiler
-COPY --from=tools /async-profiler/build /app/async-profiler/build
+COPY --from=async-profiler-builder /src/async-profiler/build /app/async-profiler/build
+COPY --from=tools /jcmd /opt/jdk
 RUN chmod +x /app/async-profiler/profiler.sh
 RUN mkdir -p /app/jfr/settings
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/jvm/jfr-profile.jfc /app/jfr/settings

--- a/docker/jvm/alpine/Dockerfile
+++ b/docker/jvm/alpine/Dockerfile
@@ -35,7 +35,7 @@ RUN $JAVA_HOME/bin/jlink \
 
 FROM --platform=$TARGETPLATFORM alpine:3.18.4
 RUN mkdir -p /app/async-profiler/build
-RUN apk add --no-cache procps
+RUN apk add --no-cache procps coreutils
 COPY --from=agentbuild /go/bin/agent /app
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/jvm/profiler.sh /app/async-profiler
 COPY --from=async-profiler-builder /src/async-profiler/build /app/async-profiler/build


### PR DESCRIPTION
ADDED: switched to buildx to ease the multi-platform builds
ADDED: Variabilization of the async-profiler version
CHANGED: switched to supported version of Java container images as a base images
fixes #34