### PR TITLE
chore(deps): Bump from rbspy v0.36.1 to v0.39.0

### DIFF
--- a/docker/ruby/Dockerfile
+++ b/docker/ruby/Dockerfile
@@ -8,7 +8,7 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/agent
 FROM rust:1.89-trixie AS rbspybuild
 WORKDIR /
 RUN git clone https://github.com/brendangregg/FlameGraph  \
-    && git clone --depth 1 --branch v0.36.1 https://github.com/rbspy/rbspy
+    && git clone --depth 1 --branch v0.39.0 https://github.com/rbspy/rbspy
 WORKDIR /rbspy
 RUN cargo build --release
 


### PR DESCRIPTION
This pull request updates the version of `rbspy` used in the Ruby Docker build process. The change ensures the build uses a newer, potentially more stable or feature-rich version of the profiling tool.

Dependency update:

* Updated the `rbspy` dependency in the Ruby Dockerfile from version `v0.36.1` to `v0.39.0` to ensure the Docker image uses a more recent version of the profiler.