### PR TITLE
chore: use cargo addr2line

### DIFF
--- a/docker/rust/Dockerfile
+++ b/docker/rust/Dockerfile
@@ -9,7 +9,8 @@ WORKDIR /go/src/github.com/josepdcs/kubectl-prof/cmd/agent
 RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /go/bin/agent
 
 FROM rust:1.89-trixie AS rusttools
-RUN cargo install flamegraph
+RUN cargo install flamegraph && \
+    cargo install addr2line --features="bin"
 
 FROM bitnami/minideb:trixie
 # Install dependencies including perf and sudo
@@ -27,6 +28,7 @@ ENV PATH="/app:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 COPY --from=agentbuild /go/bin/agent /app/agent
 COPY --from=rusttools /usr/local/cargo/bin/flamegraph /app/flamegraph
+COPY --from=rusttools /usr/local/cargo/bin/addr2line /usr/bin/addr2line
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/get-ps-command.sh /app/get-ps-command.sh
 COPY --from=agentbuild /go/src/github.com/josepdcs/kubectl-prof/contrib/perf-wrapper.sh /app/perf
 RUN chmod +x /app/get-ps-command.sh && chmod +x /app/perf


### PR DESCRIPTION
https://crates.io/crates/addr2line, based on https://github.com/gimli-rs/addr2line, has been demonstrated to have a large performance improvement over binutils addr2line.

Local testing with my application results in a 75x less time to process the symbols:  ~375s vs ~5s